### PR TITLE
Remove compilation error when compiler is gcc-7

### DIFF
--- a/test_cpy.c
+++ b/test_cpy.c
@@ -64,6 +64,7 @@ int main(int argc, char **argv)
     printf("ternary_tree, loaded %d words in %.6f sec\n", idx, t2 - t1);
 
     for (;;) {
+        char *p;
         printf(
             "\nCommands:\n"
             " a  add word to the tree\n"
@@ -73,9 +74,8 @@ int main(int argc, char **argv)
             " q  quit, freeing all data\n\n"
             "choice: ");
         fgets(word, sizeof word, stdin);
-
+        p = NULL;
         switch (*word) {
-            char *p = NULL;
         case 'a':
             printf("enter word to add: ");
             if (!fgets(word, sizeof word, stdin)) {

--- a/test_ref.c
+++ b/test_ref.c
@@ -65,6 +65,7 @@ int main(int argc, char **argv)
     printf("ternary_tree, loaded %d words in %.6f sec\n", idx, t2 - t1);
 
     for (;;) {
+        char *p;
         printf(
             "\nCommands:\n"
             " a  add word to the tree\n"
@@ -74,9 +75,8 @@ int main(int argc, char **argv)
             " q  quit, freeing all data\n\n"
             "choice: ");
         fgets(word, sizeof word, stdin);
-
+        p = NULL;
         switch (*word) {
-            char *p = NULL;
         case 'a':
             printf("enter word to add: ");
             if (!fgets(word, sizeof word, stdin)) {


### PR DESCRIPTION
There are two error messages when compiler is gcc-7.

test_cpy.c:78:19: error:
    statement will never be executed [-Werror=switch-unreachable]
test_ref.c:79:19: error:
    statement will never be executed [-Werror=switch-unreachable]

Move 'p = NULL;' outside the switch {...} block to solve it.